### PR TITLE
Integrate Coil for loading images

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,8 @@ dependencies {
 
     implementation(libs.androidx.datastore.preferences)
 
+    implementation(libs.io.coil.compose)
+
     testImplementation(platform(libs.org.junit.bom))
     testImplementation(libs.org.junit.jupiter.api)
     testImplementation(libs.org.junit.jupiter.engine)

--- a/app/src/main/java/com/rendox/grocerygenius/screens/edit_grocery/EditGroceryScreen.kt
+++ b/app/src/main/java/com/rendox/grocerygenius/screens/edit_grocery/EditGroceryScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
@@ -22,19 +22,22 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.rendox.grocerygenius.R
-import com.rendox.grocerygenius.screens.edit_grocery.dialogs.PickerDialogType
 import com.rendox.grocerygenius.screens.edit_grocery.dialogs.CategoryPickerDialog
 import com.rendox.grocerygenius.screens.edit_grocery.dialogs.IconPickerDialog
+import com.rendox.grocerygenius.screens.edit_grocery.dialogs.PickerDialogType
 import com.rendox.grocerygenius.ui.components.BottomSheetDragHandle
 import com.rendox.grocerygenius.ui.theme.GroceryGeniusTheme
+import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -121,14 +124,16 @@ fun EditGroceryScreen(
         }
 
         PickerDialogType.IconPicker -> {
+            val context = LocalContext.current
             IconPickerDialog(
                 modifier = Modifier,
                 numOfIcons = screenState.icons.size,
-                icon = {
-                    Icon(
-                        modifier = Modifier.fillMaxSize(),
-                        painter = painterResource(R.drawable.sample_grocery_icon),
+                icon = { index ->
+                    AsyncImage(
+                        modifier = modifier.fillMaxSize(),
+                        model = File(context.filesDir, screenState.icons[index].filePath),
                         contentDescription = null,
+                        colorFilter = ColorFilter.tint(color = LocalContentColor.current)
                     )
                 },
                 title = { screenState.icons[it].name },

--- a/app/src/main/java/com/rendox/grocerygenius/screens/grocery_list/GroceryListScreen.kt
+++ b/app/src/main/java/com/rendox/grocerygenius/screens/grocery_list/GroceryListScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextMotion
 import androidx.compose.ui.text.style.TextOverflow
@@ -81,6 +82,7 @@ import com.rendox.grocerygenius.ui.components.grocery_list.LazyGroceryGridItem
 import com.rendox.grocerygenius.ui.components.grocery_list.groceryListItemColors
 import com.rendox.grocerygenius.ui.theme.GroceryGeniusTheme
 import kotlinx.coroutines.launch
+import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -184,7 +186,7 @@ fun GroceryListRoute(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GroceryListScreen(
+private fun GroceryListScreen(
     modifier: Modifier = Modifier,
     groceryGroups: List<GroceryGroup>,
     searchQuery: String,
@@ -365,6 +367,7 @@ private fun GroceryGrid(
     onGroceryClick: (Grocery) -> Unit,
     onGroceryLongClick: (Grocery) -> Unit,
 ) {
+    val context = LocalContext.current
     GroupedLazyGroceryGrid(
         modifier = modifier,
         groceryGroups = groceryGroups,
@@ -383,7 +386,11 @@ private fun GroceryGrid(
                 } else {
                     MaterialTheme.colorScheme.groceryListItemColors.defaultBackgroundColor
                 },
-                groceryIcon = null,
+                iconFile = remember(grocery.icon?.filePath) {
+                    grocery.icon?.filePath?.let { filePath ->
+                        File(context.filesDir, filePath)
+                    }
+                }
             )
         },
         contentPadding = PaddingValues(

--- a/app/src/main/java/com/rendox/grocerygenius/screens/grocery_list/GroceryListViewModel.kt
+++ b/app/src/main/java/com/rendox/grocerygenius/screens/grocery_list/GroceryListViewModel.kt
@@ -254,6 +254,7 @@ class GroceryListViewModel @Inject constructor(
                     category = product.category,
                     purchasedLastModified = correspondingGroceryInTheList?.purchasedLastModified
                         ?: System.currentTimeMillis(),
+                    icon = product.icon,
                 )
             }
 

--- a/app/src/main/java/com/rendox/grocerygenius/screens/grocery_list/add_grocery_bottom_sheet/AddGroceryBottomSheetContent.kt
+++ b/app/src/main/java/com/rendox/grocerygenius/screens/grocery_list/add_grocery_bottom_sheet/AddGroceryBottomSheetContent.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -46,6 +47,7 @@ import com.rendox.grocerygenius.ui.helpers.ObserveUiEvent
 import com.rendox.grocerygenius.ui.helpers.UiEvent
 import com.rendox.grocerygenius.ui.theme.CornerRoundingDefault
 import com.rendox.grocerygenius.ui.theme.GroceryGeniusTheme
+import java.io.File
 import kotlin.random.Random
 
 @Composable
@@ -192,6 +194,7 @@ private fun SearchResults(
     onGrocerySearchResultClick: (Grocery) -> Unit,
     onCustomProductClick: (CustomProduct) -> Unit,
 ) {
+    val context = LocalContext.current
     LazyGroceryGrid(
         modifier = modifier,
         groceries = grocerySearchResults,
@@ -207,7 +210,11 @@ private fun SearchResults(
                 } else {
                     MaterialTheme.colorScheme.groceryListItemColors.defaultBackgroundColor
                 },
-                groceryIcon = null,
+                iconFile = remember(grocery.icon?.filePath) {
+                    grocery.icon?.filePath?.let { filePath ->
+                        File(context.filesDir, filePath)
+                    }
+                }
             )
         },
         customProduct = customProduct?.let { product ->
@@ -219,7 +226,7 @@ private fun SearchResults(
                     groceryName = product.name,
                     groceryDescription = product.description,
                     color = MaterialTheme.colorScheme.groceryListItemColors.defaultBackgroundColor,
-                    groceryIcon = null,
+                    iconFile = null,
                 )
             }
         }

--- a/app/src/main/java/com/rendox/grocerygenius/ui/components/GroceryIcon.kt
+++ b/app/src/main/java/com/rendox/grocerygenius/ui/components/GroceryIcon.kt
@@ -1,0 +1,70 @@
+package com.rendox.grocerygenius.ui.components
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import coil.compose.SubcomposeAsyncImageContent
+import com.rendox.grocerygenius.ui.theme.trainOneFontFamily
+import java.io.File
+
+@Composable
+fun GroceryIcon(
+    modifier: Modifier = Modifier,
+    groceryName: String,
+    iconFile: File?,
+) {
+    if (iconFile != null) {
+        SubcomposeAsyncImage(
+            modifier = modifier,
+            model = iconFile,
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(color = LocalContentColor.current),
+        ) {
+            if (painter.state is AsyncImagePainter.State.Error) {
+                TextIcon(title = groceryName)
+            } else {
+                SubcomposeAsyncImageContent(
+                    modifier = Modifier
+                        .padding(top = 4.dp)
+                        .fillMaxSize()
+                )
+            }
+        }
+    } else {
+        TextIcon(title = groceryName)
+    }
+}
+
+@Composable
+private fun TextIcon(
+    modifier: Modifier = Modifier,
+    title: String,
+) {
+    BoxWithConstraints(contentAlignment = Alignment.Center) {
+        val groceryNameFirstLetter = title.firstOrNull()?.uppercaseChar()
+        val boxWithConstraintsScope = this
+        val density = LocalDensity.current
+        Text(
+            modifier = modifier
+                .fillMaxHeight()
+                .offset(y = (-4).dp),
+            text = groceryNameFirstLetter?.toString() ?: "",
+            style = MaterialTheme.typography.headlineLarge,
+            fontFamily = trainOneFontFamily,
+            fontSize = with(density) { boxWithConstraintsScope.maxHeight.toSp() * 0.8F },
+        )
+    }
+}

--- a/app/src/main/java/com/rendox/grocerygenius/ui/components/grocery_list/GroceryGridItem.kt
+++ b/app/src/main/java/com/rendox/grocerygenius/ui/components/grocery_list/GroceryGridItem.kt
@@ -3,14 +3,10 @@ package com.rendox.grocerygenius.ui.components.grocery_list
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -19,8 +15,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -29,14 +23,15 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.rendox.grocerygenius.ui.theme.trainOneFontFamily
+import com.rendox.grocerygenius.ui.components.GroceryIcon
+import java.io.File
 
 @Composable
 fun LazyGroceryGridItem(
     modifier: Modifier = Modifier,
     groceryName: String,
     groceryDescription: String?,
-    groceryIcon: ImageBitmap?,
+    iconFile: File?,
     color: Color,
 ) {
     Surface(
@@ -69,7 +64,7 @@ fun LazyGroceryGridItem(
                 ) {
                     GroceryIcon(
                         groceryName = groceryName,
-                        bitmap = groceryIcon,
+                        iconFile = iconFile,
                     )
                 }
                 Box(
@@ -77,7 +72,8 @@ fun LazyGroceryGridItem(
                     contentAlignment = Alignment.Center,
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        val titleFontSize = if (titleLayoutResult.hasVisualOverflow) 12.sp else 14.sp
+                        val titleFontSize =
+                            if (titleLayoutResult.hasVisualOverflow) 12.sp else 14.sp
                         Text(
                             modifier = Modifier.padding(top = 4.dp),
                             text = groceryName,
@@ -105,39 +101,10 @@ fun LazyGroceryGridItem(
     }
 }
 
-@Composable
-private fun GroceryIcon(
-    modifier: Modifier = Modifier,
-    groceryName: String,
-    bitmap: ImageBitmap?,
-) {
-    BoxWithConstraints {
-        val density = LocalDensity.current
-        val boxWithConstraintsScope = this
-        if (bitmap != null) {
-            bitmap.prepareToDraw()
-            Icon(
-                modifier = modifier.padding(top = 4.dp).fillMaxSize(),
-                bitmap = bitmap,
-                contentDescription = null,
-            )
-        } else {
-            val groceryNameFirstLetter = groceryName.firstOrNull()?.uppercaseChar()
-            Text(
-                modifier = modifier.fillMaxHeight().offset(y = (-4).dp),
-                text = groceryNameFirstLetter?.toString() ?: "",
-                style = MaterialTheme.typography.headlineLarge,
-                fontFamily = trainOneFontFamily,
-                fontSize = with(density) { boxWithConstraintsScope.maxHeight.toSp() * 0.8F },
-            )
-        }
-    }
-}
-
-class NameParameterProvider : PreviewParameterProvider<Pair<String, String?>> {
+class GridItemPreviewParameterProvider : PreviewParameterProvider<Pair<String, String?>> {
     override val values: Sequence<Pair<String, String?>>
         get() = sequenceOf(
-            "Mocarella" to null,
+            "Mozzarella" to null,
             "Dishwashing" to "Lemon Scent",
             "Echo Glow Smart Lamp" to "for kids room",
         )
@@ -146,13 +113,13 @@ class NameParameterProvider : PreviewParameterProvider<Pair<String, String?>> {
 @Preview
 @Composable
 private fun LazyGroceryGridItemPreview(
-    @PreviewParameter(NameParameterProvider::class) titleAndDescription: Pair<String, String>,
+    @PreviewParameter(GridItemPreviewParameterProvider::class) titleAndDescription: Pair<String, String>,
 ) {
     LazyGroceryGridItem(
         modifier = Modifier.size(104.dp),
         groceryName = titleAndDescription.first,
         groceryDescription = titleAndDescription.second,
         color = MaterialTheme.colorScheme.groceryListItemColors.defaultBackgroundColor,
-        groceryIcon = null,
+        iconFile = null,
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ androidLifecycle = "2.7.0"
 androidxWork = "2.9.0"
 androidxTestRunner = "1.5.2"
 agp = "8.2.1"
+coilCompose = "2.6.0"
 coreKtx = "1.12.0"
 composeBom = "2024.02.01"
 coreSplashscreen = "1.0.1"
@@ -54,6 +55,8 @@ com-squareup-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", versio
 com-squareup-moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+
+io-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
 


### PR DESCRIPTION
This PR adds the Coil library to the project and uses it for loading grocery icons from files on the device's internal storage. The reason for using Coil is significant performance improvement as it loads only those images that are necessary, caches them in memory, and makes many other performance optimizations.

**Why not load images from the remote data source directly in the way it is done commonly?** Because the app is designed to be able to work fully offline after all the necessary data is preloaded initially. That data includes default groceries, categories, and icons. AFAIK, Coil loads images on demand so the only way to cache all of them to internal storage is to ask users to navigate to all places in the app where they are displayed, which is obviously a terrible user experience. Therefore, I chose to handle downloading and saving them to internal storage manually.