### PR TITLE
Fix multiple navigation issue when clicking category button

### DIFF
--- a/app/src/main/java/com/rendox/grocerygenius/feature/grocery_list/GroceryListScreen.kt
+++ b/app/src/main/java/com/rendox/grocerygenius/feature/grocery_list/GroceryListScreen.kt
@@ -77,8 +77,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextMotion
@@ -88,6 +86,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.dropUnlessResumed
 import com.rendox.grocerygenius.R
 import com.rendox.grocerygenius.feature.add_grocery.AddGroceryBottomSheetContent
 import com.rendox.grocerygenius.feature.add_grocery.AddGroceryBottomSheetState
@@ -143,8 +142,11 @@ fun GroceryListRoute(
     ObserveUiEvent(closeGroceryListScreenEvent) {
         navigateBack()
     }
-    ObserveUiEvent(navigateToCategoryScreenEvent) {
+    val navigateToCategoryScreenSafely = dropUnlessResumed {
         navigateToCategoryScreen()
+    }
+    ObserveUiEvent(navigateToCategoryScreenEvent) {
+        navigateToCategoryScreenSafely()
     }
 
     val addBottomSheetState = rememberStandardBottomSheetState()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 activityCompose = "1.9.0"
 agp = "8.3.0"
 andoridxHilt = "1.2.0"
-androidLifecycle = "2.7.0"
+androidLifecycle = "2.8.5"
 androidxTestRunner = "1.5.2"
 androidxWork = "2.9.0"
 coilCompose = "2.6.0"


### PR DESCRIPTION
- Prevents multiple navigations triggered by rapid category button clicks on GroceryListScreen, ensuring the app navigates to the category screen only once.
- Updated Android lifecycle libraries to version 2.8.5 for better state management.
- Wrapped navigation code in `dropUnlessResumed` to ensure navigation occurs only once.